### PR TITLE
Remove PSR-7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arbiter
 
-A PSR-7 Action system for Action-Domain-Responder.
+An Action system for Action-Domain-Responder.
 
 This package is installable and PSR-4 autoloadable via Composer as `arbiter/arbiter`.
 

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,8 @@
 {
     "name": "arbiter/arbiter",
     "type": "library",
-    "description": "A PSR-7 Action system for Action-Domain-Responder.",
+    "description": "An Action system for Action-Domain-Responder.",
     "keywords": [
-        "middleware",
-        "psr-7",
         "adr",
         "action domain responder"
     ],
@@ -17,16 +15,12 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
-        "psr/http-message": "~1.0"
+        "php": ">=5.5.0"
     },
     "autoload": {
         "psr-4": {
             "Arbiter\\": "src/"
         }
-    },
-    "require-dev": {
-        "zendframework/zend-diactoros": "~1.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/ActionHandler.php
+++ b/src/ActionHandler.php
@@ -8,9 +8,6 @@
  */
 namespace Arbiter;
 
-use Psr\Http\Message\ResponseInterface as Response;
-use Psr\Http\Message\ServerRequestInterface as Request;
-
 /**
  *
  * Actually performs a given Action: collects input, sends that input to the
@@ -51,14 +48,14 @@ class ActionHandler
      *
      * @param Action $action The Action to perform.
      *
-     * @param Request $request The HTTP request.
+     * @param mixed $request the input context
      *
-     * @param Response $response The HTTP response.
+     * @param mixed $response the output context
      *
-     * @return Response The HTTP response.
+     * @return mixed the output of the responder
      *
      */
-    public function handle(Action $action, Request $request, Response $response)
+    public function handle(Action $action, $request, $response)
     {
         $responder = $this->resolve($action->getResponder());
         if (! $responder) {


### PR DESCRIPTION
There's actually nothing about this package that is PSR-7 specific.

The type hints in `ActionHandler` are gratuitous, as the `handle` method *does not* actually rely on any of those interfaces actually being defined. The only thing the method does is pass those values to other places which should type hint their requirements as necessary. 

This isn't really the middleware either, the [handler which extends this in radar](https://github.com/radarphp/Radar.Adr/blob/1.x/src/Handler/ActionHandler.php) is. That's the place where PSR-7 is actually required. 

I would think this package could be used in, for example, @andrewshell [CliAdr](https://github.com/cadrephp/Cadre.CliAdr)... [specifically here](https://github.com/cadrephp/Cadre.CliAdr/blob/0.x/src/Adr.php#L28-L45)


eg. Why wouldn't I be allowed to use this package like this?

```php
<?php

use Arbiter\ActionHandler;
use Arbiter\ActionFactory;

use Aura\Cli\CliFactory;
use Aura\Cli\Context;
use Aura\Cli\Stdio;
use Aura\Cli\Status;


$resolver = function ($class) {
    return new $class;
};


class Input {

    protected $options = [];

    public function __invoke(Context $context)
    {
        return [$context->getopt($this->options)->get(1, 'World')];
    }
}

class SayHelloDomain {
    public function __invoke($noun = 'World')
    {
        return 'Hello ' . $noun;
    }
}

class Responder {
    public function __invoke(Context $context, Stdio $stdio, $payload)
    {
        $context;
        $stdio->outln($payload);
        return Status::SUCCESS;
    }
}

$cli_factory = new CliFactory;
$action_factory = new ActionFactory;

$action  = $action_factory->newInstance(
    Input::class,
    SayHelloDomain::class,
    Responder::class
);

$handler = new ActionHandler($resolver);
$context = $cli_factory->newContext($GLOBALS);
$stdio   = $cli_factory->newStdio();


exit($handler->handle($action, $context, $stdio));

```


