### PR TITLE
Feature/psr15

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ To run the tests, issue `composer install` to install the test dependencies, the
 
 An _Action_ value object is composed of three elements:
 
-- an `$input` callable: this collects input from the incoming _ServerRequestInterface_ and converts it to an array of parameters suitable for `call_user_func_array()`;
+- an `$input` callable: this collects input from the incoming _RequestContext_ and converts it to an array of parameters suitable for `call_user_func_array()`;
 
 - a `$domain` callable: this is invoked via `call_user_func_array()` using the array of parameters provided by the `$input` callable; and
 
-- a `$responder` callable: this is invoked with the incoming _ServerRequestInterface_, the outgoing _ResponseInterface_, and the result (or "payload") returned by the `$domain` callable.
+- a `$responder` callable: this is invoked with the incoming _RequestContext_, and the result (or "payload") returned by the `$domain` callable.
 
-Call the _ActionHandler_ `handle()` method with the _Action_, a _ServerRequestInterface_, and a _ResponseInterface_. The _ActionHandler_ then acts as a mediator to direct the interaction between the three callables, and returns a modified _ResponseInterface_.
+Call the _ActionHandler_ `act()` method with the _Action_, and a _RequestContext_. The _ActionHandler_ then acts as a mediator to direct the interaction between the three callables, and returns a modified _ResponseRepresentation_.

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
     "require": {
         "php": ">=5.5.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^6.5"
+    },
     "autoload": {
         "psr-4": {
             "Arbiter\\": "src/"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,4 +4,9 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/ActionHandler.php
+++ b/src/ActionHandler.php
@@ -50,12 +50,10 @@ class ActionHandler
      *
      * @param mixed $request The input context.
      *
-     * @param mixed $response The output context.
-     *
      * @return mixed The return from the responder.
      *
      */
-    public function handle(Action $action, $request, $response)
+    public function act(Action $action, $request)
     {
         $responder = $this->resolve($action->getResponder());
         if (! $responder) {
@@ -64,7 +62,7 @@ class ActionHandler
 
         $domain = $this->resolve($action->getDomain());
         if (! $domain) {
-            return $responder($request, $response);
+            return $responder($request);
         }
 
         $params = [];
@@ -74,7 +72,7 @@ class ActionHandler
         }
 
         $payload = call_user_func_array($domain, $params);
-        return $responder($request, $response, $payload);
+        return $responder($request, $payload);
     }
 
     /**

--- a/tests/ActionHandlerTest.php
+++ b/tests/ActionHandlerTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Arbiter;
 
-class ActionHandlerTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ActionHandlerTest extends TestCase
 {
     protected $actionHandler;
     protected $actionFactory;
@@ -23,10 +25,9 @@ class ActionHandlerTest extends \PHPUnit_Framework_TestCase
 
     protected function assertResponse(Action $action, $request, $expect)
     {
-        $response = $this->actionHandler->handle(
+        $response = $this->actionHandler->act(
             $action,
-            $request,
-            []
+            $request
         );
         $this->assertEquals($expect, $response['output']);
     }
@@ -41,9 +42,8 @@ class ActionHandlerTest extends \PHPUnit_Framework_TestCase
             return "Hello $noun";
         };
 
-        $responder = function ($request, $response, $payload) {
-            $response['output'] = $payload;
-            return $response;
+        $responder = function ($request, $payload) {
+            return ['output' => $payload];
         };
 
         $action = $this->newAction($input, $domain, $responder);
@@ -60,9 +60,8 @@ class ActionHandlerTest extends \PHPUnit_Framework_TestCase
             return 'no input';
         };
 
-        $responder = function ($request, $response, $payload) {
-            $response['output'] = $payload;
-            return $response;
+        $responder = function ($request, $payload) {
+            return ['output' => $payload];
         };
 
         $action = $this->newAction($input, $domain, $responder);
@@ -76,9 +75,8 @@ class ActionHandlerTest extends \PHPUnit_Framework_TestCase
 
         $domain = null;
 
-        $responder = function ($request, $response) {
-            $response['output'] = 'no domain';
-            return $response;
+        $responder = function ($request, $payload = null) {
+            return ['output' => 'no domain'];
         };
 
         $action = $this->newAction($input, $domain, $responder);
@@ -93,7 +91,7 @@ class ActionHandlerTest extends \PHPUnit_Framework_TestCase
         $responder = null;
         $action = $this->newAction($input, $domain, $responder);
 
-        $this->setExpectedException(
+        $this->expectException(
             Exception::CLASS,
             'Could not resolve responder for action.'
         );


### PR DESCRIPTION
Thoughts? previously #5 
I changed the method `handle` to `act` because psr15 uses the method name handle.

I'm assuming here that it makes the most sense for radars responders to have a constructor dependency on the response object. 